### PR TITLE
Add even more block entities

### DIFF
--- a/block/command_block.json
+++ b/block/command_block.json
@@ -1,0 +1,38 @@
+{
+	"type": "compound",
+	"child_ref": [
+		"../ref/block-entity.json"
+	],
+	"children": {
+		"auto": {
+			"type": "byte"
+		},
+		"Command": {
+			"type": "string"
+		},
+		"conditionMet": {
+			"type": "byte"
+		},
+		"CustomName": {
+			"type": "string"
+		},
+		"LastExecution": {
+			"type": "long"
+		},
+		"LastOutput": {
+			"type": "string"
+		},
+		"powered": {
+			"type": "byte"
+		},
+		"SuccessCount": {
+			"type": "int"
+		},
+		"TrackOutput": {
+			"type": "byte"
+		},
+		"UpdateLastExecution": {
+			"type": "byte"
+		}
+	}
+}

--- a/block/comparator.json
+++ b/block/comparator.json
@@ -1,11 +1,11 @@
 {
 	"type": "compound",
 	"child_ref": [
-		"./item.json"
+		"../ref/block-entity.json"
 	],
 	"children": {
-		"Slot": {
-			"type": "byte"
+		"OutputSignal": {
+			"type": "int"
 		}
 	}
 }

--- a/block/enchanting_table.json
+++ b/block/enchanting_table.json
@@ -1,11 +1,11 @@
 {
 	"type": "compound",
 	"child_ref": [
-		"./item.json"
+		"../ref/block-entity.json"
 	],
 	"children": {
-		"Slot": {
-			"type": "byte"
+		"CustomName": {
+			"type": "string"
 		}
 	}
 }

--- a/block/end_gateway.json
+++ b/block/end_gateway.json
@@ -1,0 +1,28 @@
+{
+	"type": "compound",
+	"child_ref": [
+		"../ref/block-entity.json"
+	],
+	"children": {
+		"Age": {
+			"type": "long"
+		},
+		"ExactTeleport": {
+			"type": "byte"
+		},
+		"ExitPortal": {
+			"type": "compound",
+			"children": {
+				"X": {
+					"type": "int"
+				},
+				"Y": {
+					"type": "int"
+				},
+				"Z": {
+					"type": "int"
+				}
+			}
+		}
+	}
+}

--- a/block/furnace.json
+++ b/block/furnace.json
@@ -1,0 +1,29 @@
+{
+	"type": "compound",
+	"child_ref": [
+		"../ref/block-entity.json"
+	],
+	"children": {
+		"BurnTime": {
+			"type": "short"
+		},
+		"CookTime": {
+			"type": "short"
+		},
+		"CookTimeTotal": {
+			"type": "short"
+		},
+		"CustomName": {
+			"type": "string"
+		},
+		"Items": {
+			"type": "list",
+			"item": {
+				"ref": "../ref/inventory-item.json"
+			}
+		},
+		"Lock": {
+			"type": "string"
+		}
+	}
+}

--- a/block/group/mob_head.json
+++ b/block/group/mob_head.json
@@ -1,0 +1,7 @@
+[
+  "minecraft:creeper_head",
+  "minecraft:dragon_head",
+  "minecraft:skeleton_skull",
+  "minecraft:wither_skeleton_skull",
+  "minecraft:zombie_head"
+]

--- a/block/group/shulker_box.json
+++ b/block/group/shulker_box.json
@@ -1,0 +1,18 @@
+[
+  "minecraft:white_shulker_box",
+  "minecraft:orange_shulker_box"
+  "minecraft:magenta_shulker_box"
+  "minecraft:light_blue_shulker_box"
+  "minecraft:yellow_shulker_box"
+  "minecraft:lime_shulker_box"
+  "minecraft:pink_shulker_box"
+  "minecraft:gray_shulker_box"
+  "minecraft:light_gray_shulker_box"
+  "minecraft:cyan_shulker_box"
+  "minecraft:purple_shulker_box"
+  "minecraft:blue_shulker_box"
+  "minecraft:brown_shulker_box"
+  "minecraft:green_shulker_box"
+  "minecraft:red_shulker_box"
+  "minecraft:black_shulker_box"
+]

--- a/block/hopper.json
+++ b/block/hopper.json
@@ -1,0 +1,13 @@
+{
+	"type": "compound",
+	"child_ref": [
+		"../ref/block-entity.json",
+		"../ref/inventory-holder.json",
+		"../block/chest.json"
+	],
+	"children": {
+		"TransferCooldown": {
+			"type": "int"
+		}
+	}
+}

--- a/block/jukebox.json
+++ b/block/jukebox.json
@@ -6,9 +6,7 @@
 	"children": {
 		"RecordItem": {
 			"type": "compound",
-			"ref": [
-				"../ref/item.json"
-			]
+			"ref": "../ref/item.json"
 		}
 	}
 }

--- a/block/jukebox.json
+++ b/block/jukebox.json
@@ -1,0 +1,14 @@
+{
+	"type": "compound",
+	"child_ref": [
+		"../ref/block-entity.json"
+	],
+	"children": {
+		"RecordItem": {
+			"type": "compound",
+			"child_ref": [
+				"../ref/item.json"
+			]
+		}
+	}
+}

--- a/block/jukebox.json
+++ b/block/jukebox.json
@@ -6,7 +6,7 @@
 	"children": {
 		"RecordItem": {
 			"type": "compound",
-			"child_ref": [
+			"ref": [
 				"../ref/item.json"
 			]
 		}

--- a/block/mob_spawner.json
+++ b/block/mob_spawner.json
@@ -24,7 +24,7 @@
 		},
 		"SpawnData": {
 			"type": "compound",
-			"child_ref": [
+			"ref": [
 				"../ref/entity.json"
 			]
 		},
@@ -35,7 +35,7 @@
 				"children": {
 					"Entity": {
 						"type": "compound",
-						"child_ref": [
+						"ref": [
 							"../ref/entity.json"
 						]
 					},

--- a/block/mob_spawner.json
+++ b/block/mob_spawner.json
@@ -24,9 +24,7 @@
 		},
 		"SpawnData": {
 			"type": "compound",
-			"ref": [
-				"../ref/entity.json"
-			]
+			"ref": "../ref/entity.json"
 		},
 		"SpawnPotentials": {
 			"type": "list",
@@ -35,9 +33,7 @@
 				"children": {
 					"Entity": {
 						"type": "compound",
-						"ref": [
-							"../ref/entity.json"
-						]
+						"ref": "../ref/entity.json"
 					},
 					"Weight": {
 						"type": "int"

--- a/block/mob_spawner.json
+++ b/block/mob_spawner.json
@@ -1,0 +1,52 @@
+{
+	"type": "compound",
+	"child_ref": [
+		"../ref/block-entity.json"
+	],
+	"children": {
+		"Delay": {
+			"type": "short"
+		},
+		"MaxNearbyEntities": {
+			"type": "short"
+		},
+		"MaxSpawnDelay": {
+			"type": "short"
+		},
+		"MinSpawnDelay": {
+			"type": "short"
+		},
+		"RequiredPlayerRange": {
+			"type": "short"
+		},
+		"SpawnCount": {
+			"type": "short"
+		},
+		"SpawnData": {
+			"type": "compound",
+			"child_ref": [
+				"../ref/entity.json"
+			]
+		},
+		"SpawnPotentials": {
+			"type": "list",
+			"item": {
+				"type": "compound",
+				"children": {
+					"Entity": {
+						"type": "compound",
+						"child_ref": [
+							"../ref/entity.json"
+						]
+					},
+					"Weight": {
+						"type": "int"
+					}
+				}
+			}
+		},
+		"SpawnRange": {
+			"type": "short"
+		}
+	}
+}

--- a/block/player_head.json
+++ b/block/player_head.json
@@ -1,0 +1,38 @@
+{
+	"type": "compound",
+	"child_ref": [
+		"../ref/block-entity.json"
+	],
+	"children": {
+		"Owner": {
+			"type": "compound",
+			"children": {
+				"Id": {
+					"type": "string"
+				},
+				"Name": {
+					"type": "string"
+				},
+				"Properties": {
+					"type": "compound",
+					"children": {
+						"textures": {
+							"type": "list",
+							"item": {
+								"type": "compound",
+								"children": {
+									"Value": {
+										"type": "string"
+									},
+									"Signature": {
+										"type": "string"
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/block/sign.json
+++ b/block/sign.json
@@ -1,0 +1,20 @@
+{
+	"type": "compound",
+	"child_ref": [
+		"../ref/block-entity.json"
+	],
+	"children": {
+		"Text1": {
+			"type": "string"
+		},
+		"Text2": {
+			"type": "string"
+		},
+		"Text3": {
+			"type": "string"
+		},
+		"Text4": {
+			"type": "string"
+		}
+	}
+}

--- a/block/structure_block.json
+++ b/block/structure_block.json
@@ -1,0 +1,62 @@
+{
+	"type": "compound",
+	"child_ref": [
+		"../ref/block-entity.json"
+	],
+	"children": {
+		"author": {
+			"type": "string"
+		},
+		"ignoreEntities": {
+			"type": "byte"
+		},
+		"integrity": {
+			"type": "float"
+		},
+		"metadata": {
+			"type": "string"
+		},
+		"mirror": {
+			"type": "string"
+		},
+		"mode": {
+			"type": "string"
+		},
+		"name": {
+			"type": "string"
+		},
+		"posX": {
+			"type": "int"
+		},
+		"posY": {
+			"type": "int"
+		},
+		"posZ": {
+			"type": "int"
+		},
+		"powered": {
+			"type": "byte"
+		},
+		"rotation": {
+			"type": "string"
+		},
+		"seed": {
+			"type": "long"
+		},
+		"showair": {
+			"type": "byte"
+		},
+		"showboundingbox": {
+			"type": "byte"
+		},
+		"sizeX": {
+			"type": "int"
+		},
+		"sizeY": {
+			"type": "int"
+		},
+		"sizeZ": {
+			"type": "int"
+		}
+	}
+}

--- a/ref/item.json
+++ b/ref/item.json
@@ -1,0 +1,17 @@
+{
+	"type": "compound",
+	"children": {
+		"Count": {
+			"type": "byte"
+		},
+		"Damage": {
+			"type": "short"
+		},
+		"id": {
+			"type": "string"
+		},
+		"tag": {
+			"type": "compound"
+		}
+	}
+}

--- a/roots/blocks.json
+++ b/roots/blocks.json
@@ -4,6 +4,12 @@
 		"none": {
 			"type": "no-nbt"
 		},
+		"$../block/group/mob_head.json": {
+			"ref": "../ref/block-entity.json"
+		},
+		"$../block/group/shulker_box.json": {
+			"ref": "../block/chest.json"
+		},
 		"minecraft:banner": {
 			"ref": "../block/banner.json"
 		},
@@ -17,6 +23,57 @@
 			"ref": "../block/brewing_stand.json"
 		},
 		"minecraft:chest": {
+			"ref": "../block/chest.json"
+		},
+		"minecraft:command_block": {
+			"ref": "../block/command_block.json"
+		},
+		"minecraft:comparator": {
+			"ref": "../block/comparator.json"
+		},
+		"minecraft:daylight_detector": {
+			"ref": "../ref/block-entity.json"
+		},
+		"minecraft:dispenser": {
+			"ref": "../block/chest.json"
+		},
+		"minecraft:dropper": {
+			"ref": "../block/chest.json"
+		},
+		"minecraft:enchanting_table": {
+			"ref": "../block/enchanting_table.json"
+		},
+		"minecraft:end_gateway": {
+			"ref": "../block/end_gateway.json"
+		},
+		"minecraft:end_portal": {
+			"ref": "../ref/block-entity.json"
+		},
+		"minecraft:ender_chest": {
+			"ref": "../ref/block-entity.json"
+		},
+		"minecraft:furnace": {
+			"ref": "../block/furnace.json"
+		},
+		"minecraft:hopper": {
+			"ref": "../block/hopper.json"
+		},
+		"minecraft:jukebox": {
+			"ref": "../block/jukebox.json"
+		},
+		"minecraft:mob_spawner": {
+			"ref": "../block/mob_spawner.json"
+		},
+		"minecraft:player_head": {
+			"ref": "../block/player_head.json"
+		},
+		"minecraft:sign": {
+			"ref": "../block/sign.json"
+		},
+		"minecraft:structure_block": {
+			"ref": "../block/structure_block.json"
+		},
+		"minecraft:trapped_chest": {
 			"ref": "../block/chest.json"
 		}
 	}


### PR DESCRIPTION
All block entities (as of the time of writing) should now theoretically be added.

Stuff that may be important:
- `/blocks/player_head.json` According to the wiki, `player_head`s have a `Signature` tag in their `texture`s. However, I could not get this tag to show up. Since I don't know the workings of `player_head` textures, I added the tag anyway.
- `/blocks/structure_block.json` The tags `integrity`, `powered`, `seed`, `showair` and `showboundingbox` are not on the wiki but do seem to exist (try placing down a structure block and use `data get`).
- I sorted the tag names for everything I added alphabetically, meaning the most helpful result might not be at the top.